### PR TITLE
Feature/add option to compile macos addins on windows

### DIFF
--- a/src/VbaCompiler/Vba/ModuleUnit.cs
+++ b/src/VbaCompiler/Vba/ModuleUnit.cs
@@ -45,13 +45,13 @@ namespace vbamc.Vba
             _ => this.Name,
         };
 
-        public static ModuleUnit FromFile(string path, ModuleUnitType type, string? userProfilePath)
+        public static ModuleUnit FromFile(string path, ModuleUnitType type, string? userProfilePath, bool compileForMacOnWindows = false)
         {
             var name = Path.GetFileNameWithoutExtension(path);
             var content = File.ReadAllText(path);
             userProfilePath = userProfilePath ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
-            content = content.Replace("~/", userProfilePath + Path.DirectorySeparatorChar);
+            content = content.Replace("~/", userProfilePath + (compileForMacOnWindows ? "/" : Path.DirectorySeparatorChar));
 
             var module = new ModuleUnit
             {

--- a/src/VbaCompiler/VbaCompiler.cs
+++ b/src/VbaCompiler/VbaCompiler.cs
@@ -23,21 +23,27 @@ namespace vbamc
 
         public string? UserProfilePath { get; set; }
 
+        /// <summary>
+        /// Set to true for instance of VbaCompiler if generating add-ins on windows but are used on macOS to 
+        /// explicitly set directory separator char for macOS - otherwise platform default is used 
+        /// </summary>
+        public bool CompileForMacOnWindows { get; set; } = false;
+
         public void AddModule(string path)
         {
-            var module = ModuleUnit.FromFile(path, ModuleUnitType.Module, this.UserProfilePath);
+            var module = ModuleUnit.FromFile(path, ModuleUnitType.Module, this.UserProfilePath, this.CompileForMacOnWindows);
             this.modules.Add(module);
         }
 
         public void AddClass(string path)
         {
-            var @class = ModuleUnit.FromFile(path, ModuleUnitType.Class, this.UserProfilePath);
+            var @class = ModuleUnit.FromFile(path, ModuleUnitType.Class, this.UserProfilePath, this.CompileForMacOnWindows);
             this.modules.Add(@class);
         }
 
         public void AddThisDocument(string path)
         {
-            var document = ModuleUnit.FromFile(path, ModuleUnitType.Document, this.UserProfilePath);
+            var document = ModuleUnit.FromFile(path, ModuleUnitType.Document, this.UserProfilePath, this.CompileForMacOnWindows);
             this.modules.Add(document);
         }
 


### PR DESCRIPTION
This PR solves problem that occurs when add-in is compiled on windows but used on macOS. Current implementation uses directory separator of the current system `Path.DirectorySeparatorChar` when replacing relative path  `~/` - on windows this is replaced with `\\` and on macOS with `/`. If the add-in is generated on windows, the paths in VB scripts are replaced like `Users/username\Library/...` Which leads to errors when trying to use such add-ins in Office for macOS.