### PR TITLE
Produce dir.bin only in debug mode

### DIFF
--- a/src/VbaCompiler/VbaCompiler.cs
+++ b/src/VbaCompiler/VbaCompiler.cs
@@ -103,8 +103,10 @@ namespace vbamc
 
             DirectoryEx.EnsureDirectory(intermediatePath);
 
+#if DEBUG
             var dirDebugPath = Path.Combine(intermediatePath, "dir.bin");
             File.WriteAllBytes(dirDebugPath, dirContent);
+#endif
 
             var projectOutputPath = Path.Combine(intermediatePath, projectFilename);
             storage.Save(projectOutputPath);


### PR DESCRIPTION
Generating macro files in batch can cause to write `dir.bin` file by multiple threads at once, which lead to `IOException`. It was communicated with @jozefizso and this file is used only for debugging purposes, so it will be produced only in Debug mode.