### PR TITLE
Add read file access to prevent concurrency

### DIFF
--- a/src/VbaCompiler/VbaCompiler.cs
+++ b/src/VbaCompiler/VbaCompiler.cs
@@ -229,7 +229,7 @@ namespace vbamc
             {
                 var imageFilename = Path.GetFileNameWithoutExtension(imagePath);
                 var imagePart = ribbonPart.AddImagePart(ImagePartType.Png, imageFilename);
-                using var imageStream = new FileStream(imagePath, FileMode.Open);
+                using var imageStream = new FileStream(imagePath, FileMode.Open, FileAccess.Read);
                 imagePart.FeedData(imageStream);
             }
         }


### PR DESCRIPTION
This change will prevent for concurrent task to lock the image files when instantiating stream