### PR TITLE
Add support for extended properties to the `vbamc` command line tool

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -13,10 +13,10 @@ MODULES = Module1.vb
 CLASSES = Class1.vb
 
 bin/PresentationAddin.ppam: $(MODULES) $(CLASSES)
-	../src/vbamc/bin/Debug/$(framework)/vbamc -m $(MODULES) -c $(CLASSES) -f "PresentationAddin.ppam" -n "Sample Addin" --company "ACME"
+	../src/vbamc/bin/Debug/$(framework)/vbamc -m $(MODULES) -c $(CLASSES) -f "PresentationAddin.ppam" -n "Sample Addin" --company "ACME" -p Generator=VbaCompiler
 
 bin/PresentationAddin.pptm: $(MODULES) $(CLASSES)
-	../src/vbamc/bin/Debug/$(framework)/vbamc -m $(MODULES) -c $(CLASSES) -f "PresentationAddin.pptm" -n "Sample Addin" --company "ACME"
+	../src/vbamc/bin/Debug/$(framework)/vbamc -m $(MODULES) -c $(CLASSES) -f "PresentationAddin.pptm" -n "Sample Addin" --company "ACME" -p Generator=VbaCompiler
 
 .PHONY: clean
 clean:

--- a/src/vbamc/Program.cs
+++ b/src/vbamc/Program.cs
@@ -38,6 +38,9 @@ public class Program
     [Option("--user-profile-path", Description = "Path to the user profile to replace the ~/ expression")]
     public string? UserProfilePath { get; }
 
+    [Option("-p|--property", Description = "Extended property in the format name=value")]
+    public string[] ExtendedProperties { get; } = Array.Empty<string>();
+
     private void OnExecute()
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -88,6 +91,11 @@ public class Program
             compiler.AddClass(path);
         }
 
+        foreach (var property in this.ExtendedProperties)
+        {
+            var parts = property.Split('=');
+            compiler.ExtendedProperties.Add(parts[0], parts[1]);
+        }
 
         DirectoryEx.EnsureDirectory(outputPath);
         using var outputMacroFile = File.Create(Path.Combine(outputPath, this.FileName));


### PR DESCRIPTION
This change exposes the `VbaCompiler.ExtendedProperties` to the `vbamc` tool.

### Usage

Call `vbamc` with the argument `--property` with key value pair `PropertyName=Value`:

```
vbamc -m Module.vba -c Class.vba --property Generator=VbaCompiler
```

This will create extended property named `Generator` with value `VbaCompiler` in the compiled Office document.