### PR TITLE
Modernize release.yml workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
       run: dotnet test --no-build --no-restore
 
     - name: pack
-      run: dotnet pack --no-build --no-restore -o dist
+      run: |
+        dotnet pack src/VbaCompiler/VbaCompiler.csproj --no-build --no-restore -o dist
+        dotnet pack src/vbamc/vbamc.csproj --no-build --no-restore -o dist
 
     - name: attestation
       uses: actions/attest-build-provenance@v3


### PR DESCRIPTION
Use Trusted Publishing to authenticate with NuGet Gallery.

Add attestation of released nuget packages.