### PR TITLE
Add script to setup .NET 10 SDK in Codex environment

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+###
+### Codex environment setup script. 
+###
+set -euo pipefail
+
+# Download and install .NET 10 SDK
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+bash ./dotnet-install.sh --channel 10.0 --install-dir /usr/local/dotnet
+ln -sf /usr/local/dotnet/dotnet /usr/local/bin/dotnet
+
+# configure system with dotnet
+cat >/etc/profile.d/dotnet.sh <<'EOF'
+export DOTNET_ROOT=/usr/local/dotnet
+export PATH=/usr/local/dotnet:$PATH
+export PATH=$HOME/.dotnet/tools:$PATH
+EOF
+
+# clean up
+rm -rf ./dotnet-install.sh


### PR DESCRIPTION
To run the `dotnet restore` or `dotnet build` commands successfully, you must enable the network access in Codex environment for this domain:

```
api.nuget.org
```

It is also recommended to add these environment variables to Codex environment definition:

```
DOTNET_NOLOGO: 1
DOTNET_CLI_TELEMETRY_OPTOUT: 1
DOTNET_GENERATE_ASPNET_CERTIFICATE: 0
```
